### PR TITLE
feat: adding hooks to socket/process lookup

### DIFF
--- a/getpid.go
+++ b/getpid.go
@@ -5,10 +5,8 @@ import (
 	"github.com/BurntSushi/xgbutil/xprop"
 )
 
-type runHook func() bool
-
-//IsRunningHook provides a method to override the method which detects if i3 is running or not
-var IsRunningHook runHook = func() bool {
+// IsRunningHook provides a method to override the method which detects if i3 is running or not
+var IsRunningHook = func() bool {
 	xu, err := xgbutil.NewConn()
 	if err != nil {
 		return false // X session terminated

--- a/getpid.go
+++ b/getpid.go
@@ -5,7 +5,10 @@ import (
 	"github.com/BurntSushi/xgbutil/xprop"
 )
 
-func i3Running() bool {
+type runHook func() bool
+
+//IsRunningHook provides a method to override the method which detects if i3 is running or not
+var IsRunningHook runHook = func() bool {
 	xu, err := xgbutil.NewConn()
 	if err != nil {
 		return false // X session terminated
@@ -20,4 +23,8 @@ func i3Running() bool {
 		return false
 	}
 	return pidValid(int(num))
+}
+
+func i3Running() bool {
+	return IsRunningHook()
 }

--- a/socket.go
+++ b/socket.go
@@ -24,14 +24,26 @@ var remote struct {
 	mu    sync.Mutex
 }
 
+//commandHook interface provides an override method signature usable by SocketPathHook and IsRunningHook
+type commandHook func() (string, error)
+
+//SocketPathHook Provides a way to override the default socket path
+var SocketPathHook commandHook = func() (string, error) {
+	out, err := exec.Command("i3", "--get-socketpath").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("getting i3 socketpath: %v (output: %s)", err, out)
+	}
+	return string(out), nil
+}
+
 func getIPCSocket(updateSocketPath bool) (*socket, net.Conn, error) {
 	remote.mu.Lock()
 	defer remote.mu.Unlock()
 	path := remote.path
 	if updateSocketPath || remote.path == "" {
-		out, err := exec.Command("i3", "--get-socketpath").CombinedOutput()
+		out, err := SocketPathHook()
 		if err != nil {
-			return nil, nil, fmt.Errorf("getting i3 socketpath: %v (output: %s)", err, out)
+			return nil, nil, err
 		}
 		path = strings.TrimSpace(string(out))
 	}

--- a/socket.go
+++ b/socket.go
@@ -24,11 +24,8 @@ var remote struct {
 	mu    sync.Mutex
 }
 
-//commandHook interface provides an override method signature usable by SocketPathHook and IsRunningHook
-type commandHook func() (string, error)
-
-//SocketPathHook Provides a way to override the default socket path
-var SocketPathHook commandHook = func() (string, error) {
+// SocketPathHook Provides a way to override the default socket path lookup mechanism. Overriding this is unsupported.
+var SocketPathHook = func() (string, error) {
 	out, err := exec.Command("i3", "--get-socketpath").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("getting i3 socketpath: %v (output: %s)", err, out)

--- a/version.go
+++ b/version.go
@@ -3,6 +3,7 @@ package i3
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 )
 
 // Version describes an i3 version.
@@ -12,6 +13,7 @@ type Version struct {
 	Major                int64  `json:"major"`
 	Minor                int64  `json:"minor"`
 	Patch                int64  `json:"patch"`
+	Variant              string `json:"variant,omitempty"`
 	HumanReadable        string `json:"human_readable"`
 	LoadedConfigFileName string `json:"loaded_config_file_name"`
 }
@@ -47,6 +49,10 @@ func AtLeast(major int64, minor int64) error {
 		if err != nil {
 			return err
 		}
+	}
+	if version.Variant != "" {
+		log.Printf("non standard i3 payload variant '%s' detected. Ignoring version check. This is fully unsupported.", version.Variant)
+		return nil
 	}
 	if version.Major == major && version.Minor >= minor {
 		return nil


### PR DESCRIPTION
~Still need a solution for Version as sway reports as 1.1 but~ the rest of it is working as expected:

```
package main

import (
	"bytes"
	"fmt"
	"log"
	"os/exec"

	"go.i3wm.org/i3"
)

func main() {
	i3.SocketPathHook = func() (string, error) {
		out, err := exec.Command("sway", "--get-socketpath").CombinedOutput()
		if err != nil {
			return "", fmt.Errorf("getting sway socketpath: %v (output: %s)", err, out)
		}
		return string(out), nil
	}

	i3.IsRunningHook = func() bool {
		out, err := exec.Command("pgrep", "-c", "sway\\$").CombinedOutput()
		if err != nil {
			log.Printf("sway running: %v (output: %s)", err, out)
		}
		return bytes.Compare(out, []byte("1")) == 0
	}

	ws, err := i3.GetWorkspaces()
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("workspaces:\n %s\n", ws)
}

```