### PR TITLE
Break the event receiver after Close()

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -1,0 +1,62 @@
+package i3
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestCloseSubprocess runs in a process which has been started with
+// DISPLAY= pointing to an Xvfb instance with i3 -c testdata/i3.config running.
+func TestCloseSubprocess(t *testing.T) {
+	if os.Getenv("GO_WANT_XVFB") != "1" {
+		t.Skip("parent process")
+	}
+
+	ws := Subscribe(WorkspaceEventType)
+	received := make(chan Event)
+	go func() {
+		defer close(received)
+		for ws.Next() {
+		}
+		received <- nil
+	}()
+	ws.Close()
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for a Close()")
+	}
+}
+
+func TestClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, canc := context.WithCancel(context.Background())
+	defer canc()
+
+	_, DISPLAY, err := launchXvfb(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup, err := launchI3(ctx, DISPLAY, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCloseSubprocess", "-test.v")
+	cmd.Env = []string{
+		"GO_WANT_XVFB=1",
+		"DISPLAY=" + DISPLAY,
+		"PATH=" + os.Getenv("PATH"),
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err.Error())
+	}
+}

--- a/subscribe.go
+++ b/subscribe.go
@@ -107,6 +107,7 @@ type EventReceiver struct {
 	ev        Event
 	err       error
 	reconnect bool
+	closed    bool
 }
 
 // Event returns the most recent event received from i3 by a call to Next.
@@ -209,6 +210,10 @@ Outer:
 			return true // happy path
 		}
 
+		if r.closed {
+			return false
+		}
+
 		// reconnect
 		start := time.Now()
 		for time.Since(start) < reconnectTimeout && (r.sock == nil || i3Running()) {
@@ -228,6 +233,7 @@ Outer:
 // Close closes the connection to i3. If you don’t ever call Close, you must
 // consume events via Next to prevent i3 from deadlocking.
 func (r *EventReceiver) Close() error {
+	r.closed = true
 	if r.conn != nil {
 		if r.err == nil {
 			r.err = r.conn.Close()


### PR DESCRIPTION
While developing an app based on go-i3 I noticed that calling `Close()` on an EventReceiver instance doesn't break exit the `Next()` method. This causes application to be unable to exit cleanly if a separate go routine is polling for events using `Next()`, because `Next()` doesn't return.

This happens because`r.next()` in `Next()` returns the following error from the underlying socket library: `read unix @->/run/user/1000/i3/ipc-socket.13342: use of closed network connection`. After receiving it `Next()` enters the reconnect phase, instead of returning `false` as an indicator of a closed connection.

This fix causes `Next()` to correctly return `false` after `Close()`, allowing the caller to exit cleanly.